### PR TITLE
Tree nil empty tests

### DIFF
--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -247,3 +247,14 @@ func TestNodeRightChild(t *testing.T) {
 		}
 	})
 }
+
+func TestIsNil(t *testing.T) {
+	var bt1 *BinarySearchTree[prInt]
+
+	want := true
+	got := bt1.IsNil()
+
+	if got != want {
+		t.Errorf("IsNil() returned incorrect results, want: %v, got :%v", want, got)
+	}
+}

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -270,3 +270,14 @@ func TestIsNil(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEmpty(t *testing.T) {
+	var bst1 *BinarySearchTree[prInt]
+
+	want := true
+	got := bst1.IsEmpty()
+
+	if got != want {
+		t.Errorf("IsEmpty() returned incorrect results, want: %v, got :%v", want, got)
+	}
+}

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -277,23 +277,22 @@ func TestIsEmpty(t *testing.T) {
 	root := &Node[prInt]{}
 	bst3 = &BinarySearchTree[prInt]{root}
 
-	want := true
-	got := bst1.IsEmpty()
-
-	if got != want {
-		t.Errorf("IsEmpty() returned incorrect results, want: %v, got :%v", want, got)
+	tests := []struct {
+		name string
+		bst  *BinarySearchTree[prInt]
+		want bool
+	}{
+		{"nil tree", bst1, true},
+		{"non nil, empty tree", bst2, true},
+		{"non nil, non empty tree", bst3, false},
 	}
 
-	got = bst2.IsEmpty()
-
-	if got != want {
-		t.Errorf("IsEmpty() returned incorrect results, want: %v, got :%v", want, got)
-	}
-
-	want = false
-	got = bst3.IsEmpty()
-
-	if got != want {
-		t.Errorf("IsEmpty() returned incorrect results, want: %v, got :%v", want, got)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.bst.IsEmpty()
+			if got != test.want {
+				t.Errorf("IsNil() returned incorrect results, want: %v, got :%v", test.want, got)
+			}
+		})
 	}
 }

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -272,10 +272,17 @@ func TestIsNil(t *testing.T) {
 }
 
 func TestIsEmpty(t *testing.T) {
-	var bst1 *BinarySearchTree[prInt]
+	var bst1, bst2 *BinarySearchTree[prInt]
+	bst2 = &BinarySearchTree[prInt]{}
 
 	want := true
 	got := bst1.IsEmpty()
+
+	if got != want {
+		t.Errorf("IsEmpty() returned incorrect results, want: %v, got :%v", want, got)
+	}
+
+	got = bst2.IsEmpty()
 
 	if got != want {
 		t.Errorf("IsEmpty() returned incorrect results, want: %v, got :%v", want, got)

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -272,8 +272,10 @@ func TestIsNil(t *testing.T) {
 }
 
 func TestIsEmpty(t *testing.T) {
-	var bst1, bst2 *BinarySearchTree[prInt]
+	var bst1, bst2, bst3 *BinarySearchTree[prInt]
 	bst2 = &BinarySearchTree[prInt]{}
+	root := &Node[prInt]{}
+	bst3 = &BinarySearchTree[prInt]{root}
 
 	want := true
 	got := bst1.IsEmpty()
@@ -283,6 +285,13 @@ func TestIsEmpty(t *testing.T) {
 	}
 
 	got = bst2.IsEmpty()
+
+	if got != want {
+		t.Errorf("IsEmpty() returned incorrect results, want: %v, got :%v", want, got)
+	}
+
+	want = false
+	got = bst3.IsEmpty()
 
 	if got != want {
 		t.Errorf("IsEmpty() returned incorrect results, want: %v, got :%v", want, got)

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -249,21 +249,24 @@ func TestNodeRightChild(t *testing.T) {
 }
 
 func TestIsNil(t *testing.T) {
-	var bt1 *BinarySearchTree[prInt]
+	var bst1, bst2 *BinarySearchTree[prInt]
+	bst2 = &BinarySearchTree[prInt]{}
 
-	want := true
-	got := bt1.IsNil()
-
-	if got != want {
-		t.Errorf("IsNil() returned incorrect results, want: %v, got :%v", want, got)
+	tests := []struct {
+		name string
+		bst  *BinarySearchTree[prInt]
+		want bool
+	}{
+		{"nil tree", bst1, true},
+		{"non nil tree", bst2, false},
 	}
 
-	var bt2 = &BinarySearchTree[prInt]{}
-
-	want = false
-	got = bt2.IsNil()
-
-	if got != want {
-		t.Errorf("IsNil() returned incorrect results, want: %v, got :%v", want, got)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.bst.IsNil()
+			if got != test.want {
+				t.Errorf("IsNil() returned incorrect results, want: %v, got :%v", test.want, got)
+			}
+		})
 	}
 }

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -257,4 +257,13 @@ func TestIsNil(t *testing.T) {
 	if got != want {
 		t.Errorf("IsNil() returned incorrect results, want: %v, got :%v", want, got)
 	}
+
+	var bt2 = &BinarySearchTree[prInt]{}
+
+	want = false
+	got = bt2.IsNil()
+
+	if got != want {
+		t.Errorf("IsNil() returned incorrect results, want: %v, got :%v", want, got)
+	}
 }


### PR DESCRIPTION
added tests for the IsNil() and IsEmpty() methods on the binary search tree, and made them table driven