### PR TITLE
Bstree traverse dfs inorder

### DIFF
--- a/bstreelib/bstreelib.go
+++ b/bstreelib/bstreelib.go
@@ -177,7 +177,7 @@ func (bst *BinarySearchTree[T]) TraverseDFSInOrder() (string, error) {
 		return "", treeEmptyError
 	}
 
-	return "", nil
+	return recurseDFSInOrder(bst.root), nil
 }
 
 func recurseDFSInOrder[T BinarySearchTreeElement](node *Node[T]) string {

--- a/bstreelib/bstreelib.go
+++ b/bstreelib/bstreelib.go
@@ -167,3 +167,7 @@ func (bst *BinarySearchTree[T]) TraverseBFS() (string, error) {
 
 	return treeStr, nil
 }
+
+func (bst *BinarySearchTree[T]) TraverseDFSInOrder() (string, error) {
+	return "", nil
+}

--- a/bstreelib/bstreelib.go
+++ b/bstreelib/bstreelib.go
@@ -168,6 +168,9 @@ func (bst *BinarySearchTree[T]) TraverseBFS() (string, error) {
 	return treeStr, nil
 }
 
+// TraverseDFSInOrder returns a string that represents the traversal order of nodes using Depth First Search
+// In an in-order manner (visit a node's left subtree, then the node itself, followed by its right subtree)
+// This method uses recursion
 func (bst *BinarySearchTree[T]) TraverseDFSInOrder() (string, error) {
 	if bst.IsNil() {
 		return "", treeNilError

--- a/bstreelib/bstreelib.go
+++ b/bstreelib/bstreelib.go
@@ -179,3 +179,15 @@ func (bst *BinarySearchTree[T]) TraverseDFSInOrder() (string, error) {
 
 	return "", nil
 }
+
+func recurseDFSInOrder[T BinarySearchTreeElement](node *Node[T]) string {
+	if node == nil {
+		return ""
+	}
+
+	result := recurseDFSInOrder(node.left)
+	result += fmt.Sprintf("-(%v)-", node.data)
+	result += recurseDFSInOrder(node.right)
+
+	return result
+}

--- a/bstreelib/bstreelib.go
+++ b/bstreelib/bstreelib.go
@@ -169,5 +169,13 @@ func (bst *BinarySearchTree[T]) TraverseBFS() (string, error) {
 }
 
 func (bst *BinarySearchTree[T]) TraverseDFSInOrder() (string, error) {
+	if bst.IsNil() {
+		return "", treeNilError
+	}
+
+	if bst.IsEmpty() {
+		return "", treeEmptyError
+	}
+
 	return "", nil
 }


### PR DESCRIPTION
added a method to perform an in-order depth first traversal (recursive) of a binary search tree