### PR TITLE
Extend node parent tests

### DIFF
--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -79,8 +79,11 @@ func TestNodeParent(t *testing.T) {
 				t.Fatalf("ConstructFromValues() failed with error: %v", err)
 			}
 
-			// gather expected parent strings
-			expParents := []string{"nil", "1", "3", "3", "5", "5", "7"}
+			// gather expected parent prInt pointers
+			var pr1, pr3, pr5, pr7 *prInt
+			*pr1, *pr3, *pr5, *pr7 = 1, 3, 5, 7
+
+			expParents := []*prInt{nil, pr1, pr3, pr3, pr5, pr5, pr7}
 		})
 	})
 

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -3,6 +3,7 @@ package bstreelib
 import (
 	"errors"
 	"fmt"
+	"github.com/pluckynumbat/go-quez/sgquezlib"
 	"testing"
 )
 
@@ -84,6 +85,16 @@ func TestNodeParent(t *testing.T) {
 			*pr1, *pr3, *pr5, *pr7 = 1, 3, 5, 7
 
 			expParents := []*prInt{nil, pr1, pr3, pr3, pr5, pr5, pr7}
+
+			// construct an expected parent queue from the above pointers
+			qParents := sgquezlib.SemiGenericQueue[*prInt]{}
+			for _, p := range expParents {
+				err = qParents.Enqueue(p)
+				if err != nil {
+					t.Fatalf("Enqueue() failed with error: %v", err)
+				}
+			}
+
 		})
 	})
 

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -81,10 +81,8 @@ func TestNodeParent(t *testing.T) {
 			}
 
 			// gather expected parent prInt pointers
-			var pr1, pr3, pr5, pr7 *prInt
-			*pr1, *pr3, *pr5, *pr7 = 1, 3, 5, 7
-
-			expParents := []*prInt{nil, pr1, pr3, pr3, pr5, pr5, pr7}
+			var pr1, pr3, pr5, pr7 prInt = 1, 3, 5, 7
+			expParents := []*prInt{nil, &pr1, &pr3, &pr3, &pr5, &pr5, &pr7}
 
 			// construct an expected parent queue from the above pointers
 			qParents := sgquezlib.SemiGenericQueue[*prInt]{}

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -79,6 +79,8 @@ func TestNodeParent(t *testing.T) {
 				t.Fatalf("ConstructFromValues() failed with error: %v", err)
 			}
 
+			// gather expected parent strings
+			expParents := []string{"nil", "1", "3", "3", "5", "5", "7"}
 		})
 	})
 

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -100,6 +100,50 @@ func TestNodeParent(t *testing.T) {
 				t.Fatalf("Enqueue() failed with error: %v", err)
 			}
 
+			// do a BFS traversal of the tree, checking each node's parents against the expected parent
+			for !queue.IsEmpty() {
+
+				runner, err2 := queue.Dequeue()
+				if err2 != nil {
+					t.Fatalf("Dequeue() failed with error: %v", err2)
+				}
+
+				actualParent, err2 := runner.Parent()
+				if err2 != nil {
+					t.Fatalf("Parent() failed with error: %v", err2)
+				}
+				got := "nil"
+				if actualParent != nil {
+					got = actualParent.String()
+				}
+
+				expectedParent, err2 := qParents.Dequeue()
+				if err2 != nil {
+					t.Fatalf("Dequeue() failed with error: %v", err2)
+				}
+				want := "nil"
+				if expectedParent != nil {
+					want = expectedParent.String()
+				}
+
+				if got != want {
+					t.Errorf("Parent() returned incorrect results, want: %v, got: %v", want, got)
+				}
+
+				if runner.left != nil {
+					err2 = queue.Enqueue(runner.left)
+					if err2 != nil {
+						t.Fatalf("Enqueue() failed with error: %v", err2)
+					}
+				}
+
+				if runner.right != nil {
+					err2 = queue.Enqueue(runner.right)
+					if err2 != nil {
+						t.Fatalf("Enqueue() failed with error: %v", err2)
+					}
+				}
+			}
 		})
 	})
 

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -178,6 +178,78 @@ func TestNodeParent(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("test node parent on all nodes of a binary search tree", func(t *testing.T) {
+			bst, err := ConstructFromValues[prString]("b", "d", "f", "a", "c", "e", "g")
+			if err != nil {
+				t.Fatalf("ConstructFromValues() failed with error: %v", err)
+			}
+
+			// gather expected parent prInt pointers
+			var prB, prD, prF prString = "b", "d", "f"
+			expParents := []*prString{nil, &prB, &prB, &prD, &prD, &prF, &prF}
+
+			// construct an expected parent queue from the above pointers
+			qParents := sgquezlib.SemiGenericQueue[*prString]{}
+			for _, p := range expParents {
+				err = qParents.Enqueue(p)
+				if err != nil {
+					t.Fatalf("Enqueue() failed with error: %v", err)
+				}
+			}
+
+			// set up queue for a breadth first search traversal of the binary search tree
+			queue := sgquezlib.SemiGenericQueue[*Node[prString]]{}
+			err = queue.Enqueue(bst.root)
+			if err != nil {
+				t.Fatalf("Enqueue() failed with error: %v", err)
+			}
+
+			// do a BFS traversal of the tree, checking each node's parents against the expected parent
+			for !queue.IsEmpty() {
+
+				runner, err2 := queue.Dequeue()
+				if err2 != nil {
+					t.Fatalf("Dequeue() failed with error: %v", err2)
+				}
+
+				actualParent, err2 := runner.Parent()
+				if err2 != nil {
+					t.Fatalf("Parent() failed with error: %v", err2)
+				}
+				got := "nil"
+				if actualParent != nil {
+					got = actualParent.String()
+				}
+
+				expectedParent, err2 := qParents.Dequeue()
+				if err2 != nil {
+					t.Fatalf("Dequeue() failed with error: %v", err2)
+				}
+				want := "nil"
+				if expectedParent != nil {
+					want = expectedParent.String()
+				}
+
+				if got != want {
+					t.Errorf("Parent() returned incorrect results, want: %v, got: %v", want, got)
+				}
+
+				if runner.left != nil {
+					err2 = queue.Enqueue(runner.left)
+					if err2 != nil {
+						t.Fatalf("Enqueue() failed with error: %v", err2)
+					}
+				}
+
+				if runner.right != nil {
+					err2 = queue.Enqueue(runner.right)
+					if err2 != nil {
+						t.Fatalf("Enqueue() failed with error: %v", err2)
+					}
+				}
+			}
+		})
 	})
 }
 

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -95,6 +95,13 @@ func TestNodeParent(t *testing.T) {
 				}
 			}
 
+			// set up queue for a breadth first search traversal of the binary search tree
+			queue := sgquezlib.SemiGenericQueue[*Node[prInt]]{}
+			err = queue.Enqueue(bst.root)
+			if err != nil {
+				t.Fatalf("Enqueue() failed with error: %v", err)
+			}
+
 		})
 	})
 

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -74,7 +74,11 @@ func TestNodeParent(t *testing.T) {
 		}
 
 		t.Run("test node parent on all nodes of a binary search tree", func(t *testing.T) {
-			
+			bst, err := ConstructFromValues[prInt](1, 3, 5, 7, 2, 4, 6)
+			if err != nil {
+				t.Fatalf("ConstructFromValues() failed with error: %v", err)
+			}
+
 		})
 	})
 

--- a/bstreelib/bstreelib_test.go
+++ b/bstreelib/bstreelib_test.go
@@ -72,6 +72,10 @@ func TestNodeParent(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("test node parent on all nodes of a binary search tree", func(t *testing.T) {
+			
+		})
 	})
 
 	t.Run("test node parent: prString", func(t *testing.T) {


### PR DESCRIPTION
extended node parent tests: added a sub test to check the parent of each node in a binary search tree